### PR TITLE
Update to use filters

### DIFF
--- a/includes/tuition-fees-common.php
+++ b/includes/tuition-fees-common.php
@@ -12,9 +12,13 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Common' ) ) {
 		 * @param $items Array | The array of tuition and fee items
 		 **/
 		public static function display( $items, $title, $layout='default', $args=array() ) {
-			if ( has_action( 'ucf_tuition_fees_display_' . $layout ) ) {
-				do_action( 'ucf_tuition_fees_display_' . $layout, $items, $title, $args );
+			$content = display_default( $items, $title, $args );
+
+			if ( has_filter( 'ucf_tuition_fees_display_' . $layout ) ) {
+				$content = apply_filters( 'ucf_tuition_fees_display_' . $layout, $content, $items, $title, $args );
 			}
+
+			return $content;
 		}
 
 		/**
@@ -78,7 +82,7 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Common' ) ) {
 				</tbody>
 			</table>
 		<?php
-			echo ob_get_clean();
+			return ob_get_clean();
 		}
 	}
 }

--- a/includes/tuition-fees-common.php
+++ b/includes/tuition-fees-common.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Common' ) ) {
 		 * @param $items Array | The array of tuition and fee items
 		 **/
 		public static function display( $items, $title, $layout='default', $args=array() ) {
-			$content = display_default( $items, $title, $args );
+			$content = self::display_default( $items, $title, $args );
 
 			if ( has_filter( 'ucf_tuition_fees_display_' . $layout ) ) {
 				$content = apply_filters( 'ucf_tuition_fees_display_' . $layout, $content, $items, $title, $args );

--- a/tuition-fees.php
+++ b/tuition-fees.php
@@ -28,5 +28,3 @@ add_action( 'admin_menu', array( 'UCF_Tuition_Fees_Config', 'add_options_page' )
 add_action( 'admin_enqueue_scripts', array( 'UCF_Tuition_Fees_Config', 'enqueue_admin_assets' ), 10, 1 );
 // Add the shortcode
 add_action( 'init', array( 'UCF_Tuition_Fees_Shortcode', 'register_shortcode' ) );
-// Add the default layout
-add_action( 'ucf_tuition_fees_display_default', array( 'UCF_Tuition_Fees_Common', 'display_default' ), 10, 2 );


### PR DESCRIPTION
Updated plugin to use filters instead of actions, which fixes the error where content appears at the top of the page (because it was being echoed and not returned).