### PR TITLE
Compatibility with new UCF Search Service/Degree CPT Plugin updates

### DIFF
--- a/importers/tuition-fees-importer.php
+++ b/importers/tuition-fees-importer.php
@@ -13,24 +13,21 @@ class Tuition_Fees_Data_Importer {
 		$skipped_total = 0,
 		$degree_count = 0,
 		$mapping = array(
-			"Doctor of Physical Therapy"                         => "DPT",
-			"Doctor of Medicine"                                 => "MD",
-			"Florida Interactive Entertainment Academy"          => "FIEA",
-			"Executive MBA"                                      => "EMBA",
-			"Professional MBA"                                   => "PMBA",
-			"Professional MS in Management/Human Resource Track" => "PMSM",
-			"Professional Master of Science in Real Estate"      => "PMRE",
-			"MS in Health Sci/Online Exec Health Svcs Admin Trk" => "EHSA",
-			"Master of Research Administration"                  => "MRA",
-			"Master of Nonprofit Management/Non-Res Cohort Trk"  => "MNM",
-			"Graduate Cert in Research Administration"           => "GCRA",
-			"MS in Healthcare Informatics"                       => "MHI",
-			"Graduate Cert in Health Information Administration" => "GCIA",
-			"Online Master of Social Work"                       => "OMSW",
-			"MS in Industrial Engr/Healthcare Systems Engr Trk"  => "MHSE",
-			"Professional MS in Engineering Management"          => "MSEM",
-			"Professional MS in Management/Business Analytics"   => "MSAN",
-			"Master of Science in Data Analytics"                => "MSDA"
+			'DPT'  => array( 'plan_code' => 'PT-DPT', 'subplan_code' => '' ),
+			'MD'   => array( 'plan_code' => 'MEDICIN-MD', 'subplan_code' => '' ),
+			'FIEA' => array( 'plan_code' => 'DIGMED-MS', 'subplan_code' => '' ),
+			'EMBA' => array( 'plan_code' => 'BUS-MBA', 'subplan_code' => 'EXEC-MBA' ),
+			'PMBA' => array( 'plan_code' => 'BUS-MBA', 'subplan_code' => 'PROF-MBA' ),
+			'PMSM' => array( 'plan_code' => 'BUS-MS', 'subplan_code' => 'BUSHR-MS' ),
+			'PMRE' => array( 'plan_code' => 'RLESTAT-MS', 'subplan_code' => '' ),
+			'EHSA' => array( 'plan_code' => 'HLTHSCI-MS', 'subplan_code' => 'ZMRHLEXECH' ),
+			'MRA'  => array( 'plan_code' => 'RCHADM-MRA', 'subplan_code' => '' ),
+			'MNM'  => array( 'plan_code' => 'NONPRFTMNM', 'subplan_code' => 'MNM-COHORT' ),
+			'GCRA' => array( 'plan_code' => 'RCHADM-CRT', 'subplan_code' => '' ),
+			'GCIA' => array( 'plan_code' => 'HCIADMCRT', 'subplan_code' => '' ),
+			'MSEM' => array( 'plan_code' => 'ENGRMGT-MS', 'subplan_code' => '' ),
+			'MSAN' => array( 'plan_code' => 'BUS-MS', 'subplan_code' => 'BUSAN-MS' ),
+			'MSD'  => array( 'plan_code' => 'DATAANAMS', 'subplan_code' => '' ),
 		);
 
 	/**
@@ -70,7 +67,7 @@ class Tuition_Fees_Data_Importer {
 		$success_percentage = round( $this->updated_total / $this->degree_count * 100 );
 		return
 "
-Successfully update tuition data.
+Successfully updated tuition data.
 Updated    : {$this->updated_total}
 Exceptions : {$this->mapped_total}
 Skipped    : {$this->skipped_total}
@@ -233,44 +230,56 @@ Success %  : {$success_percentage}%
 	 */
 	private function update_degrees() {
 		foreach( $this->degrees as $degree ) {
-			$program_types = wp_get_post_terms( $degree->ID, 'program_types' );
-			$program_type = is_array( $program_types ) ? $program_types[0] : false;
+			$parent_program_type    = wp_get_post_terms( $degree->ID, 'program_types', array( 'parent' => 0 ) );
+			$parent_program_type_id = is_array( $parent_program_type ) ? $parent_program_type[0]->term_id : 0;
+			$program_type = wp_get_post_terms( $degree->ID, 'program_types', array( 'parent' => $parent_program_type_id ) );
+			$program_type = ( is_array( $program_type ) && ! empty( $program_type ) ) ? $program_type[0] : null;
+			$plan_code    = get_post_meta( $degree->ID, UCF_Tuition_Fees_Config::get_option_or_default( 'degree_plan_code_name' ), true );
+			$subplan_code = get_post_meta( $degree->ID, UCF_Tuition_Fees_Config::get_option_or_default( 'degree_subplan_code_name' ), true );
 
 			// If no program type, skip it
 			if ( ! $program_type ) { $this->skipped_total++; continue; }
 
-			$schedule_code = $this->get_schedule_code( $program_type->name, $degree->post_title );
+			$schedule_code = $this->get_schedule_code( $program_type->name, $plan_code, $subplan_code );
 
 			// If we can't determine the program code, skip it
 			if ( ! $schedule_code ) { $this->skipped_total++; continue; }
 
-			$resident_total = $this->data[$schedule_code]['res'];
-			$non_resident_total = $this->data[$schedule_code]['nonres'];
+			if ( isset( $this->data[$schedule_code] ) ) {
+				$resident_total = $this->data[$schedule_code]['res'];
+				$non_resident_total = $this->data[$schedule_code]['nonres'];
 
-			update_post_meta( $degree->ID, 'degree_resident_tuition', $resident_total );
-			update_post_meta( $degree->ID, 'degree_nonresident_tuition', $non_resident_total );
+				update_post_meta( $degree->ID, 'degree_resident_tuition', $resident_total );
+				update_post_meta( $degree->ID, 'degree_nonresident_tuition', $non_resident_total );
 
-			$this->updated_total++;
+				$this->updated_total++;
+			}
+			else {
+				$this->skipped_total++;
+				continue;
+			}
 		}
 	}
 
-	private function get_schedule_code( $program_type, $name ) {
-		if ( in_array( $program_type, array( 'Undergraduate Degree', 'Minor' ) ) ) {
+	private function get_schedule_code( $program_type, $plan_code, $subplan_code ) {
+		if ( in_array( $program_type, array( 'Bachelor', 'Minor' ) ) ) {
 			return 'UnderGrad';
 		}
 
 		// Loop through the mapping variable and look for a match
 		// This should handle exceptions for masters degrees
-		foreach( $this->mapping as $key => $val ) {
-			if ( stripos( $name, $key ) !== false ||
-				 stripos( $name, $val ) ) {
+		foreach( $this->mapping as $sched_code => $plan_codes ) {
+			if (
+				$plan_codes['plan_code'] === $plan_code
+				&& $plan_codes['subplan_code'] === $subplan_code
+			) {
 				$this->mapped_count++;
-				return $val;
+				return $sched_code;
 			}
 		}
 
 		// If we don't have a mapping for it, skip it.
-		if ( in_array( $program_type, array( 'Accelerated Program', 'Articulated Program', 'Certificate' ) ) ) {
+		if ( in_array( $program_type, array( 'Undergraduate Certificate', 'Graduate Certificate', 'Specialist', 'Professional Program' ) ) ) {
 			return null;
 		}
 

--- a/includes/importers.php
+++ b/includes/importers.php
@@ -8,20 +8,20 @@ class Tuition_Command extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * <api>
-	 * : The url of the tuition and fees feed (Required)
+	 * [--api=<api>]
+	 * : The url of the tuition and fees feed. Defaults to the base feed url set in plugin options
 	 *
 	 * [--post-type=<post_type>]
 	 * : The post type to import data into. Defaults to `degree`
 	 *
 	 * ## EXAMPLES
 	 *
-	 * $ wp tuition import https://finacctg.fa.ucf.edu/sas/feed/feed.cfm
+	 * $ wp tuition import
 	 *
-	 * $ wp tuition import https://finacctg.fa.ucf.edu/sas/feed/feed.cfm --post-type=programs
+	 * $ wp tuition import --api="https://finacctg.fa.ucf.edu/sas/feed/feed.cfm" --post-type="programs"
 	 */
 	public function import( $args, $assoc_args ) {
-		$api = $args[0];
+		$api = isset( $assoc_args['api'] ) ? $assoc_args['api'] : UCF_Tuition_Fees_Config::get_option_or_default( 'base_feed_url' );
 		$post_type = isset( $assoc_args['post-type'] ) ? $assoc_args['post-type'] : 'degree';
 
 		$import = new Tuition_Fees_Data_Importer( $api, $post_type );

--- a/includes/tuition-fees-config.php
+++ b/includes/tuition-fees-config.php
@@ -7,10 +7,12 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
         public static
             $option_prefix   = 'ucf_tuition_fees_',
             $option_defaults = array(
-                'base_feed_url'        => 'http://www.studentaccounts.ucf.edu/feed/feed.cfm',
-				'include_css'          => false,
-				'cache_results'        => false,
-				'transient_expiration' => 3 // hours
+				'base_feed_url'            => 'https://finacctg.fa.ucf.edu/sas/feed/feed.cfm',
+				'degree_plan_code_name'    => 'degree_plan_code',
+				'degree_subplan_code_name' => 'degree_subplan_code',
+				'include_css'              => false,
+				'cache_results'            => false,
+				'transient_expiration'     => 3 // hours
             );
 
         /**
@@ -23,7 +25,9 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
         public static function add_options() {
             $defaults = self::$option_defaults;
 
-            add_option( self::$option_prefix . 'base_feed_url', $defaults['base_feed_url'] );
+			add_option( self::$option_prefix . 'base_feed_url', $defaults['base_feed_url'] );
+			add_option( self::$option_prefix . 'degree_plan_code_name', $defaults['degree_plan_code_name'] );
+			add_option( self::$option_prefix . 'degree_subplan_code_name', $defaults['degree_subplan_code_name'] );
 			add_option( self::$option_prefix . 'include_css', $defaults['include_css'] );
 			add_option( self::$option_prefix . 'cache_results', $defaults['cache_results'] );
 			add_option( self::$option_prefix . 'transient_expiration', $defaults['transient_expiration'] );
@@ -37,6 +41,8 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
 		 **/
 		public static function delete_options() {
 			delete_option( self::$option_prefix . 'base_feed_url' );
+			delete_option( self::$option_prefix . 'degree_plan_code_name' );
+			delete_option( self::$option_prefix . 'degree_subplan_code_name' );
 			delete_option( self::$option_prefix . 'include_css' );
 			delete_option( self::$option_prefix . 'cache_results' );
 			delete_option( self::$option_prefix . 'transient_expiration' );
@@ -54,10 +60,12 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
 		public static function get_option_defaults() {
 			$defaults = self::$option_defaults;
 			$configurable_defaults = array(
-				'base_feed_url'          => get_option( self::$option_prefix . 'base_feed_url' ),
-				'include_css'            => get_option( self::$option_prefix . 'include_css' ),
-				'cache_results'          => get_option( self::$option_prefix . 'cache_results' ),
-				'transient_expiration'   => get_option( self::$option_prefix . 'transient_expiration' )
+				'base_feed_url'            => get_option( self::$option_prefix . 'base_feed_url' ),
+				'degree_plan_code_name'    => get_option( self::$option_prefix . 'degree_plan_code_name' ),
+				'degree_subplan_code_name' => get_option( self::$option_prefix . 'degree_subplan_code_name' ),
+				'include_css'              => get_option( self::$option_prefix . 'include_css' ),
+				'cache_results'            => get_option( self::$option_prefix . 'cache_results' ),
+				'transient_expiration'     => get_option( self::$option_prefix . 'transient_expiration' )
 			);
 			$configurable_defaults = self::format_options( $configurable_defaults );
 			$default = array_merge( $defaults, $configurable_defaults );
@@ -121,7 +129,7 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
 		 * or a plugin option default.
 		 * @author Jo Dickson
 		 * @since 1.0.0
-		 * 
+		 *
 		 * @param $option_name
 		 * @return mixed
 		 **/
@@ -144,6 +152,8 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
 		 **/
 		public static function settings_init() {
 			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'base_feed_url' );
+			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'degree_plan_code_name' );
+			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'degree_subplan_code_name' );
 			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'include_css' );
 			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'cache_results' );
 			register_setting( 'ucf_tuition_fees', self::$option_prefix . 'transient_expiration' );
@@ -157,13 +167,39 @@ if ( ! class_exists( 'UCF_Tuition_Fees_Config' ) ) {
 
 			add_settings_field(
 				self::$option_prefix . 'base_feed_url',
-				'Enabled Post Types',
+				'Base Tuition and Fees Feed URL',
 				array( 'UCF_Tuition_Fees_Config', 'display_settings_field' ),
 				'ucf_tuition_fees',
 				'ucf_tuition_fees_general',
 				array(
 					'label_for'   => self::$option_prefix . 'base_feed_url',
 					'description' => 'The base url of the tuition and fees feed.',
+					'type'        => 'text'
+				)
+			);
+
+			add_settings_field(
+				self::$option_prefix . 'degree_plan_code_name',
+				'Degree Plan Code meta name',
+				array( 'UCF_Tuition_Fees_Config', 'display_settings_field' ),
+				'ucf_tuition_fees',
+				'ucf_tuition_fees_general',
+				array(
+					'label_for'   => self::$option_prefix . 'degree_plan_code_name',
+					'description' => 'The name of the meta field that stores individual degree plan codes.',
+					'type'        => 'text'
+				)
+			);
+
+			add_settings_field(
+				self::$option_prefix . 'degree_subplan_code_name',
+				'Degree Subplan Code meta name',
+				array( 'UCF_Tuition_Fees_Config', 'display_settings_field' ),
+				'ucf_tuition_fees',
+				'ucf_tuition_fees_general',
+				array(
+					'label_for'   => self::$option_prefix . 'degree_subplan_code_name',
+					'description' => 'The name of the meta field that stores individual degree subplan codes.',
 					'type'        => 'text'
 				)
 			);


### PR DESCRIPTION
Added updates that make the tuition + fees importer compatible with updates to UCF's Search Service and the Degree CPT Plugin.

- Updated program type names and calls for specific program types to account for updated hierarchy set by the Degree CPT Plugin's degree importer (always get the child-most program type instead of just fetching the first program type retrieved).
- Updated what program types are skipped by`Tuition_Fees_Data_Importer->get_schedule_code()` to account for new program types (Professional Program, Specialist).  I'm not actually sure if "Specialist" degrees qualify as matches for the generic "Grad" schedule code, so I'm playing it safe here by skipping them entirely.  Resolves #9.
- Updated `Tuition_Fees_Data_Importer->get_schedule_code()` to match unique schedule codes to existing degrees by plan code + subplan code, instead of by degree name.

  Some degrees imported from the new Search Service no longer have unique enough names to reliably be matched against without any other reference data.  For instance, when trying to find a match for the schedule code "GCRA", we previously searched against the degree name "Graduate Cert in Research Administration", which would've been unique enough to return a single match.  However, in the new Search Service data, that certificate is now named "Research Administration"; if we were to simply search against the degree name "Research Administration" for a schedule code match, we may incorrectly return a match for the "Master in Research Administration (MRA)" master's degree instead (or one of the other Research Administration subplans).

  To accommodate this change, I've added plugin options that allow you to define meta value names to pull degree plan and subplan values from for each degree; this should cover cases such as UCF Online that has its own custom degree CPT + metadata implementation.  These values default to the meta names we expect in the Degree CPT Plugin (`degree_plan_code` and `degree_subplan_code`).

**NOTE: we are no longer matching against the following schedule codes.  Reasons are noted below:**
'MHI': can't match this to any program
'OMSW': can't narrow down a specific match (6 possible matches)
'MHSE': there is only an online subplan offered with this name; not sure if it's an accurate match

Other minor updates:
- Fixed a potential notice in `Tuition_Fees_Data_Importer->update_degrees()` when `$this->data[$schedule_code]` is not set (lines 248-260).  If it's not set for whatever reason, we skip updating the degree.
- Updated the default base feed url.  Resolves #11
- Fixed typo in the import success message
- Fixed incorrect field label for the base feed url plugin option.  Resolves #10 
- Updated the `api` option in the tuition import command to be optional (defaults to whatever value is set in plugin options)